### PR TITLE
RTL Support CSS Fix

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 .a11y-slider-container {
   position: relative;
+  direction: ltr;
 }
 
 .a11y-slider {


### PR DESCRIPTION
I came across this issue the slider structure was not properly initializing on rtl sites.
After doing some debugging if we add `direction: ltr;` on the slider container it started working fine without any issues.